### PR TITLE
Add function for users to set extra TLS needed before calling threading APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ docs/out/
 .*/
 *~
 *.bak
+*.sh
+.clangd

--- a/include/calico/system/thread.h
+++ b/include/calico/system/thread.h
@@ -135,6 +135,10 @@ void threadPrepare(Thread* t, ThreadFunc entrypoint, void* arg, void* stack_top,
 //! @brief Returns the required size for thread-local storage (8-byte aligned) @see threadAttachLocalStorage
 size_t threadGetLocalStorageSize(void);
 
+// Sets an extra amount of thread-local storage to be allocated for threads created using
+// system calls (POSIX threads, C threads, C++ std::thread). Will be 8-byte aligned.
+void threadSetPthreadExtraTls(const size_t size);
+
 /*! @brief Attaches thread-local storage to a @ref Thread @p t
 	@param[in] storage 8-byte aligned memory buffer to use as thread-local storage,
 	or NULL to consume thread stack memory instead

--- a/source/system/newlib_syscalls.c
+++ b/source/system/newlib_syscalls.c
@@ -133,6 +133,14 @@ int __SYSCALL(cond_wait_recursive)(_COND_T* cond, _LOCK_RECURSIVE_T* lock, uint6
 	return 0;
 }
 
+static size_t extraTls = 0;
+
+void threadSetPthreadExtraTls(const size_t size)
+{
+	// make sure it's 8-byte aligned
+	extraTls = (size + 7) &~ 7;
+}
+
 int __SYSCALL(thread_create)(struct __pthread_t** thread, void* (*func)(void*), void* arg, void* stack_addr, size_t stack_size)
 {
 	if (((uptr)stack_addr & 7) || (stack_size & 7)) {
@@ -145,7 +153,7 @@ int __SYSCALL(thread_create)(struct __pthread_t** thread, void* (*func)(void*), 
 
 	size_t struct_sz = (sizeof(struct __pthread_t) + 7) &~ 7;
 
-	size_t needed_sz = struct_sz + threadGetLocalStorageSize();
+	size_t needed_sz = struct_sz + threadGetLocalStorageSize() + extraTls;
 	if (!stack_addr) {
 		needed_sz += stack_size;
 	}


### PR DESCRIPTION
## Reason for this PR
When building libcurl with `CURL_DISABLE_VERBOSE_STRINGS` set to `OFF` (verbose strings enabled), all of the internal debug `printf` calls (macro'd to libcurl's internal printf implementation, NOT newlib), to my understanding, have their format strings copied to static memory (which *can* be TLS?). However when making an HTTP request under a Calico **non-main** thread, many different crashes occur at different addresses. The only time `addr2line` gave me a proper file:line number, it pointed to [here](https://github.com/trustytrojan/curl/blob/aaaccaf785bb10b41bd1b5b10df8ea6b07e76a7f/lib/mprintf.c#L222), where the format string is trying to be read. So I theorized that the thread doesn't have enough memory, changed [this line](https://github.com/trustytrojan/calico/blob/6d437b7651ba5c95036a90f534c30079bb926945/source/system/newlib_syscalls.c#L148) to have ` + 1024` in the expression for `needed_sz`, and no crash occurred.

## Changes
- Added `void threadSetPthreadExtraTls(size_t)` to allow applications to set any extra TLS needed (will be 8-byte aligned) for the next created POSIX/C/C++ thread.
- Added `static size_t extraTls` to be able to store the extra size needed from the function above.